### PR TITLE
(perf): refactor event scheduler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,6 +208,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
+name = "crossbeam"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch",
+ "crossbeam-queue",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,6 +244,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -410,6 +441,7 @@ dependencies = [
  "bincode",
  "bytes",
  "clap",
+ "crossbeam",
  "dashmap",
  "env_logger",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,5 @@ rand = "0.8.5"
 pin-project = "1.1.5"
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.10", features = ["env-filter"] }
+crossbeam = "0.8.4"
 

--- a/src/event_scheduler.rs
+++ b/src/event_scheduler.rs
@@ -2,7 +2,6 @@ use std::collections::{BinaryHeap, HashMap};
 use std::sync::Arc;
 use tokio::sync::{mpsc, Notify, RwLock};
 use pin_project::pin_project;
-use tracing::debug;
 use std::{
     pin::Pin,
     task::{Context, Poll},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,13 +5,14 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use anyhow::{anyhow, Context as _, Result};
 use codec::MessageCodec;
+use futures::Stream as _;
 use tokio::io::{AsyncReadExt as _, AsyncWriteExt};
 use tokio::macros::support::poll_fn;
 pub use broadcast_queue::{BroadcastQueue, DefaultBroadcastQueue};
 pub use  dispatch_event_handler::DispatchEventHandler;
 use rand::{thread_rng, Rng};
 use config::{BROADCAST_FANOUT, INDIRECT_REQ, MAX_UDP_PACKET_SIZE};
-use event_scheduler::{EventState, EventType};
+use event_scheduler::{EventState, EventStream, EventType};
 use tracing::{info, warn, error, debug, instrument};
 use members::MergeAction;
 use message::{AckPayload, AppMsgPayload, Broadcast, MessagePayload, MessageType, PingPayload, PingReqPayload};
@@ -145,8 +146,10 @@ where
     /// Incarnation number, used to detect and handle node restarts
     incarnation: AtomicU64,
 
-    /// Manager for handling and creating of events
-    event_scheduler: EventScheduler,
+    /// Manager for handling and creating timestamped events
+    event_scheduler: Arc<EventScheduler>,
+
+    event_stream: Arc<EventStream>,
 
     // broadcasts represents outbound messages to peers
     // when it's not set, it defaults to DefaultBroadcastQueue
@@ -215,6 +218,8 @@ where
         let (shutdown_tx, _) = broadcast::channel(1);
         let addr = transport.local_addr().map_err(|e|anyhow!(e))?;
 
+        let event_scheduler = Arc::new(EventScheduler::new());
+        let event_stream = Arc::new(EventStream::new(event_scheduler.clone()));
         let swim = Self {
             inner: Arc::new(InnerGossipod {
                 config,
@@ -225,7 +230,8 @@ where
                 transport,
                 sequence_number: AtomicU64::new(0),
                 incarnation: AtomicU64::new(0),
-                event_scheduler: EventScheduler::new(),
+                event_scheduler: event_scheduler,
+                event_stream: event_stream,
                 broadcasts,
                 dispatch_event_handler,
             })
@@ -388,41 +394,35 @@ where
         
         tokio::spawn(async move {
             loop {
-                let sleep_duration = gossipod.inner.event_scheduler.time_to_next_event().await.unwrap_or(Duration::from_millis(500));
-
+                let mut event_stream = pin!(gossipod.inner.event_stream);
                 tokio::select! {
-                    _ = tokio::time::sleep(sleep_duration) => {
-                        let cluster_size = gossipod.inner.members.len().unwrap_or(gossipod.inner.config.initial_cluster_size);
-                        // Calculate event processing limit to balance performance and resource usage:
-                        // 1. Slow down processing if message volume is high
-                        // 2. Events are created for most pings/ping-req so it's important to the drain channel quickly to reduce memory overhead
-                        // 3. Avoid CPU spikes from processing too many messages at once
-                        // 4. Scale with cluster size, but within reasonable bounds (100-1000)
-                        // Note: This is a naive approach and may need tuning for optimal performance
-                        let limit = std::cmp::min(
-                            std::cmp::max(100, cluster_size), 
-                            1000
-                        );
-                        let events = gossipod.inner.event_scheduler.next_events(limit).await;
-                        for (event_type, event) in events {
-                            match event_type {
-                                EventType::Ack { sequence_number } => {
-                                    info!("Ack with sequence number {} TIMED OUT", sequence_number);
-                                    let _ = event.sender.try_send(event.state);
-                                },
-                                EventType::SuspectTimeout { node } => {
-                                    info!("Moving Node {} to DEAD state", node);
-                                    if let Ok(Some(node)) = gossipod.inner.members.get_node(&node) {
-                                        if node.is_suspect() {
-                                            if let Err(e)= gossipod.confirm_node_dead(&node).await {
-                                                warn!("unable to confirm dead for node: {} because of: {}", node.name, e);
-                                            }else {
-                                                info!("Successfully Moved node {} to DEAD state", node.name);
-                                            }
-                                
-                                        }
-                                    };
-                                },
+                    event = poll_fn(|cx| event_stream.as_mut().poll_next(cx)) =>{
+                        if let Some(current_event) = event {
+                            match current_event.get_state() {
+                                EventState::ReachedDeadline => {
+                                    match &current_event.event_type {
+                                        EventType::Ack { sequence_number } => {
+                                            debug!("Ack with sequence number {} TIMED OUT", sequence_number);
+                                            let _ = current_event.sender.try_send(current_event.get_state());
+                                        },
+                                        EventType::SuspectTimeout { node } => {
+                                            debug!("Moving Node {} to DEAD state", node);
+                                            if let Ok(Some(node)) = gossipod.inner.members.get_node(&node) {
+                                                if node.is_suspect() {
+                                                    if let Err(e)= gossipod.confirm_node_dead(&node).await {
+                                                        warn!("unable to confirm dead for node: {} because of: {}", node.name, e);
+                                                    }else {
+                                                        info!("Successfully Moved node {} to DEAD state", node.name);
+                                                    }
+                                        
+                                                }
+                                            };
+                                        },
+                                    }
+                                }
+                                _ => {
+                                    // Event was intercepted or cancelled, no action needed
+                                }
                             }
                         }
                     }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -57,10 +57,17 @@ impl DefaultTransport {
         let private_ip_addr = IpAddress::find_system_ip()?;
         if addr.ip().to_string() == DEFAULT_IP_ADDR || addr.ip().to_string() == "0.0.0.0" {
             info!(
-                "> [UDP] Binding to all network interfaces: {}:{} (Private IP: {}:{})",
+                "> [UDP] Binding to all network interfaces: {}:{} (Private IPv4: {}:{})",
                 addr.ip(),
                 addr.port(),
-                private_ip_addr.to_string(),
+                private_ip_addr.0.to_string(),
+                addr.port(),
+            );
+            info!(
+                "> [UDP] Binding to all network interfaces: {}:{} (Private IPv6: {}:{})",
+                addr.ip(),
+                addr.port(),
+                private_ip_addr.1.to_string(),
                 addr.port(),
             );
         } else {


### PR DESCRIPTION
### Description
Prevent busy waiting and use future to poll events only when required.

```mermaid
flowchart TD
    subgraph A["Events"]
        B["Event Scheduler"]
        C["Event Streams"]
        D[("Event Queue")]
        B --> D
        C --> D
    end
    
    subgraph X["Event Actions"]
        E(["schedule_event"])
        F(["intercept_event"])
        G((("poll")))
    end

    E --> B
    F --> B
    G --> C



````